### PR TITLE
Characters: hide hidden intimacies in API

### DIFF
--- a/app/controllers/api/v1/characters_controller.rb
+++ b/app/controllers/api/v1/characters_controller.rb
@@ -11,6 +11,16 @@ module Api
         render json: @characters
       end
 
+      def show
+        authorize @character
+
+        if policy(@character).update?
+          render json: @character
+        else
+          render json: @character.without_secrets
+        end
+      end
+
       def create
         @character = Character.new(resource_params)
         @character.player ||= current_player

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -132,4 +132,11 @@ class Character < ApplicationRecord
   def charms
     []
   end
+
+  def without_secrets
+    c = self.dup
+    c.ties.reject!{|t| t["hidden"]}
+    c.principles.reject!{|p| p["hidden"]}
+    c
+  end
 end


### PR DESCRIPTION
Currently, hidden intimacies are fully exposed through the API and
hidden in the frontend Javascript. This change modifies the API to only
return hidden intimacies for characters where the player should be able
to see them, using the same heuristic as the frontend uses currently -
update permission.

This hides player secrets from prying eyes - darn Night castes always
on the lookout for an advantage!