### PR TITLE
spec: resolve deprecation warning realted to content_type

### DIFF
--- a/spec/requests/battlegroups_spec.rb
+++ b/spec/requests/battlegroups_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Battlegroups', type: :request do
           .and(change(Battlegroup, :count).by(1))
           .and(change(QcAttack, :count).by(1))
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end

--- a/spec/requests/shared_examples/character.rb
+++ b/spec/requests/shared_examples/character.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples 'character' do |character_type, parent|
         end.to have_enqueued_job(CreateBroadcastJob)
           .and change { trait.class.count }.by 1
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end
@@ -61,7 +61,7 @@ RSpec.shared_examples 'character' do |character_type, parent|
           end.to have_enqueued_job(CreateBroadcastJob)
             .and change { trait.class.count }.by 1
 
-          expect(response.content_type).to eq 'application/json'
+          expect(response.media_type).to eq 'application/json'
           expect(response.status).to eq 200
         end
       end
@@ -72,7 +72,7 @@ RSpec.shared_examples 'character' do |character_type, parent|
         get "/api/v1/#{trait.entity_type}s/#{trait.id}",
             headers: authenticated_header(trait.player)
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end
@@ -84,7 +84,7 @@ RSpec.shared_examples 'character' do |character_type, parent|
                  headers: authenticated_header(trait.player)
         end.to change { trait.class.count }.by(-1)
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end

--- a/spec/requests/shared_examples/character_trait.rb
+++ b/spec/requests/shared_examples/character_trait.rb
@@ -18,7 +18,7 @@ RSpec.shared_examples 'character trait' do |trait_type, parent_type|
         end.to have_enqueued_job(CreateBroadcastJob)
           .and change { trait.class.count }.by(1)
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
 
@@ -39,7 +39,7 @@ RSpec.shared_examples 'character trait' do |trait_type, parent_type|
         get "/api/v1/#{parent_type}/#{trait.character.id}/#{trait.entity_type}s/#{trait.id}",
             headers: authenticated_header(trait.player)
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end
@@ -51,7 +51,7 @@ RSpec.shared_examples 'character trait' do |trait_type, parent_type|
                  headers: authenticated_header(trait.player)
         end.to change { trait.class.count }.by(-1)
 
-        expect(response.content_type).to eq 'application/json'
+        expect(response.media_type).to eq 'application/json'
         expect(response.status).to eq 200
       end
     end


### PR DESCRIPTION
At the moment, running the full LCA test suite gives me a bunch of
deprecation warnings related to content_type vs media_type:

DEPRECATION WARNING: Rails 6.1 will return Content-Type header without
modification. If you want just the MIME type, please use `#media_type`
instead.

This seems like a perfectly reasonable change to make, and making it
does not cause any tests to start failing, so this commit swaps over
uses of `content_type` to `media_type` in the test suite.

After making this change I observe no more deprecation warnings when
running `bundle exec rspec spec/`


If I've misunderstood something about the way you run tests and this isn't relevant, feel free to ignore this :smiley: