### PR TITLE
CharacterSheet: widen Limit panel to fit better

### DIFF
--- a/app/javascript/lca/components/characters/CharacterSheet.jsx
+++ b/app/javascript/lca/components/characters/CharacterSheet.jsx
@@ -268,7 +268,7 @@ export class CharacterSheet extends Component<Props> {
           </Grid>
 
           {showLimit && (
-            <Grid item xs={12} md={2}>
+            <Grid item xs={12} md={4}>
               <LimitTrackBlock character={character} />
             </Grid>
           )}


### PR DESCRIPTION
I've noticed that the Limit panel on the main character sheet view seems
to be oddly squashed, and I can't find anything that would fit in the
space it leaves, so this commit widens the Limit component grid box from
2 units to 4.

When I try this out locally, it seems to make things fit better at all
screen widths large enough to allow multiple columns, and it seems to
make no difference when everything collapses as on phones.

Obviously if I'm missing something just let me know! :smile:

I did try to run `yarn test` to validate the change, but I'm seeing a fair number of differences that I don't think I caused, do you expect those tests to be up to date? I suppose its possible something in my environment is causing things to compile differently and not match snapshots.

Before:
![Before Image](https://i.imgur.com/rf5ThXq.png)

After:
![After Image](https://i.imgur.com/4LNRW9A.png)