### PR TITLE
QC Rating Calculation Fix

### DIFF
--- a/app/javascript/lca/utils/calculated/_qcs.js
+++ b/app/javascript/lca/utils/calculated/_qcs.js
@@ -57,9 +57,14 @@ function qcExcellencyRatingCap(qc, rating, stunt = false) {
       return 0
   }
 
-  if (rating <= 2) return caps[0]
-  else if (rating <= 6) return caps[1]
-  else if (rating <= 10) return caps[2]
+  // if (rating <= 2) return caps[0]
+  // else if (rating <= 6) return caps[1]
+  // else if (rating <= 10) return caps[2]
+  // else return caps[3]
+
+  if (rating <= 1) return caps[0]
+  else if (rating <= 3) return caps[1]
+  else if (rating <= 5) return caps[2]
   else return caps[3]
 }
 

--- a/app/javascript/lca/utils/calculated/_qcs.js
+++ b/app/javascript/lca/utils/calculated/_qcs.js
@@ -57,11 +57,6 @@ function qcExcellencyRatingCap(qc, rating, stunt = false) {
       return 0
   }
 
-  // if (rating <= 2) return caps[0]
-  // else if (rating <= 6) return caps[1]
-  // else if (rating <= 10) return caps[2]
-  // else return caps[3]
-
   if (rating <= 1) return caps[0]
   else if (rating <= 3) return caps[1]
   else if (rating <= 5) return caps[2]


### PR DESCRIPTION
The current implementation uses the data from the "Pool" (2, 6, 10) table for calculating QC rating dice caps when they need to be half that to properly calculate (1,3,5)